### PR TITLE
Add player inventory with toggle and rendering

### DIFF
--- a/render.py
+++ b/render.py
@@ -25,6 +25,31 @@ E_SPRITE = pygame.image.load(E_PATH)
 E_SPRITE = pygame.transform.scale(E_SPRITE, (E_SIZE, E_SIZE))
 E_RECT = pygame.Rect(0, 0, E_SIZE, E_SIZE)
 
+
+def draw_inventory(items):
+    """Отрисовка окна инвентаря."""
+    inv_rect = pygame.Rect(0, 0, WIDTH, HEIGHT)
+    pygame.draw.rect(screen, DIALOG_COLOR, inv_rect)
+    pygame.draw.rect(screen, BORDER_COLOR, inv_rect, width=BORDER_WIDTH)
+
+    item_size = int(HEIGHT / 6)
+    padding = int(item_size * 0.5)
+    font_h = DIALOG_FONT.get_height()
+    cols = max(1, (WIDTH - padding) // (item_size + padding))
+    for i, item in enumerate(items):
+        word = item["word"]
+        path = item["texture_path"]
+        sprite = pygame.image.load(path).convert_alpha()
+        sprite = pygame.transform.scale(sprite, (item_size, item_size))
+        col = i % cols
+        row = i // cols
+        x = padding + col * (item_size + padding)
+        y = padding + row * (item_size + font_h + padding)
+        screen.blit(sprite, (x, y))
+        text_surface = DIALOG_FONT.render(word, True, TEXT_COLOR)
+        text_rect = text_surface.get_rect(center=(x + item_size // 2, y + item_size + font_h // 2))
+        screen.blit(text_surface, text_rect)
+
 screen = pygame.display.set_mode((WIDTH, HEIGHT), pygame.DOUBLEBUF)
 pygame.display.set_caption("Checheck game")
 clock = pygame.time.Clock()
@@ -55,6 +80,8 @@ while running:
                 res = current_scene.interact()
                 if res:
                     current_scene = res
+            if event.key == pygame.K_q:
+                current_scene.toggle_inventory()
                 
     screen.fill((0, 0, 0))
     scene_info = current_scene.get_draw_data()
@@ -75,7 +102,9 @@ while running:
         rect = sprite.get_rect(topleft=(x_l, y_t))
         screen.blit(sprite, rect)
 
-    if scene_info["ui"]["mode"] == "dialog":
+    if scene_info["inventory"]["open"]:
+        draw_inventory(scene_info["inventory"]["items"])
+    elif scene_info["ui"]["mode"] == "dialog":
         dialog_rect = pygame.Rect(0, HEIGHT - DIALOG_HEIGHT, WIDTH, DIALOG_HEIGHT)
         pygame.draw.rect(screen, DIALOG_COLOR, dialog_rect, border_radius=20)
         pygame.draw.rect(screen, BORDER_COLOR, dialog_rect, border_radius=20, width=BORDER_WIDTH)

--- a/scene.py
+++ b/scene.py
@@ -170,6 +170,12 @@ class Scene:
     # Порядок отрисовки игрока:
     player_z: int = 0
 
+    # --- Инвентарь ---
+    # Список элементов инвентаря (слово и путь к картинке)
+    inventory: List[Tuple[str, str]] = field(default_factory=list)
+    # Открыт ли сейчас инвентарь
+    inventory_open: bool = False
+
     _active_dialog_npc_id: Optional[str] = None
 
     # ---------- Служебные ----------
@@ -202,7 +208,7 @@ class Scene:
         return best_obj, best_dist
 
     def _update_hint(self) -> None:
-        if self._is_dialog_active():
+        if self._is_dialog_active() or self.inventory_open:
             return
         obj, dist = self._nearest_interactable()
         if obj and dist <= self.interact_distance:
@@ -214,7 +220,7 @@ class Scene:
     # ---------- Перемещение (заблокировано при диалоге) ----------
 
     def _move(self, dx: float, dy: float) -> None:
-        if self._is_dialog_active():
+        if self._is_dialog_active() or self.inventory_open:
             return
 
         new_rect_x = self._player_rect().moved(dx, 0)
@@ -228,7 +234,7 @@ class Scene:
         self._update_hint()
 
     def move_forward(self, step: float = 2.0) -> None:
-        if self._is_dialog_active():
+        if self._is_dialog_active() or self.inventory_open:
             return
         self._move(0, -step)
         self.l += (self.c % self.player_speed) == 0
@@ -237,7 +243,7 @@ class Scene:
         self.player_texture_path = self.texture_path_to_player + f'/up{self.l % 5}.png'
 
     def move_back(self, step: float = 2.0) -> None:
-        if self._is_dialog_active():
+        if self._is_dialog_active() or self.inventory_open:
             return
         self._move(0, step)
         self.l += (self.c % self.player_speed) == 0
@@ -246,7 +252,7 @@ class Scene:
         self.player_texture_path = self.texture_path_to_player + f'/down{self.l}.png'
 
     def move_left(self, step: float = 2.0) -> None:
-        if self._is_dialog_active():
+        if self._is_dialog_active() or self.inventory_open:
             return
         self._move(-step, 0)
         self.l += (self.c % self.player_speed) == 0
@@ -255,7 +261,7 @@ class Scene:
         self.player_texture_path = self.texture_path_to_player + f'/left{self.l}.png'
 
     def move_right(self,step: float = 2.0) -> None:
-        if self._is_dialog_active():
+        if self._is_dialog_active() or self.inventory_open:
             return
         self._move(step, 0)
         self.l += (self.c % self.player_speed) == 0
@@ -298,6 +304,8 @@ class Scene:
     # ---------- Взаимодействие (E) ----------
 
     def unteract(self) -> Optional["Scene"]:
+        if self.inventory_open:
+            return None
         if self._active_dialog_npc_id is not None:
             return self.next_dialog_step()
         obj, dist = self._nearest_interactable()
@@ -310,6 +318,24 @@ class Scene:
 
     def interact(self) -> Optional["Scene"]:
         return self.unteract()
+
+    # ---------- Инвентарь ----------
+
+    def add_element(self, element: Tuple[str, str]) -> None:
+        """Добавить элемент (слово, путь к картинке) в инвентарь."""
+        self.inventory.append(element)
+
+    def toggle_inventory(self) -> None:
+        """Открыть/закрыть инвентарь. Нельзя открыть во время диалога."""
+        if self._is_dialog_active():
+            return
+        self.inventory_open = not self.inventory_open
+        if self.inventory_open:
+            # Скрываем подсказки при открытии инвентаря
+            self.text_window.hide()
+        else:
+            # После закрытия обновляем подсказку
+            self._update_hint()
 
     # ---------- Данные для рендера (включая пути к текстурам) ----------
 
@@ -348,6 +374,13 @@ class Scene:
                 "text": self.text_window.text,
                 "source_object_id": self.text_window.source_object_id,
                 "dialog_active_with": self._active_dialog_npc_id,
+            },
+            "inventory": {
+                "open": self.inventory_open,
+                "items": [
+                    {"word": word, "texture_path": path}
+                    for word, path in self.inventory
+                ],
             },
         }
 


### PR DESCRIPTION
## Summary
- add inventory tracking and toggling to Scene class
- render inventory overlay and handle Q key to open/close

## Testing
- `python -m py_compile scene.py render.py`


------
https://chatgpt.com/codex/tasks/task_e_68c53055d9a4832f9700646fe37edf00