### PR TITLE
Add player inventory with toggle and rendering

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,3 +1,4 @@
 {
-    "scene": "menu"
+    "scene": "menu",
+    "inventory": []
 }

--- a/data_helper.py
+++ b/data_helper.py
@@ -1,13 +1,41 @@
 import json
+from typing import List, Dict, Optional
 
-def load_game():
+
+def load_game() -> Dict[str, object]:
+    """Load the persisted game data from ``data.json``.
+
+    Ensures that an ``inventory`` list is always present in the result.
+    """
     with open("data.json", "r", encoding="utf-8") as f:
         data = json.load(f)
+    data.setdefault("inventory", [])
     return data
 
-def save_game(scene_name):
+
+def save_game(scene_name: str, inventory: Optional[List[Dict[str, str]]] = None) -> None:
+    """Persist the current scene and inventory back to ``data.json``.
+
+    If ``inventory`` is omitted the previously saved inventory is kept.
+    """
+    data = load_game()
+    data["scene"] = scene_name
+    if inventory is not None:
+        data["inventory"] = inventory
     with open("data.json", "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=4)
 
-        scene_name="menu"
 
-        json.dump({"scene": scene_name}, f, indent=4)
+def load_inventory() -> List[Dict[str, str]]:
+    """Return the list of inventory items from the save file."""
+    return load_game().get("inventory", [])
+
+
+def add_inventory_item(word: str, texture_path: str) -> None:
+    """Append a new item to the inventory and save it."""
+    data = load_game()
+    items = data.setdefault("inventory", [])
+    items.append({"word": word, "texture_path": texture_path})
+    with open("data.json", "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=4)
+

--- a/render.py
+++ b/render.py
@@ -25,6 +25,31 @@ E_SPRITE = pygame.image.load(E_PATH)
 E_SPRITE = pygame.transform.scale(E_SPRITE, (E_SIZE, E_SIZE))
 E_RECT = pygame.Rect(0, 0, E_SIZE, E_SIZE)
 
+
+def draw_inventory(items):
+    """Отрисовка окна инвентаря."""
+    inv_rect = pygame.Rect(0, 0, WIDTH, HEIGHT)
+    pygame.draw.rect(screen, DIALOG_COLOR, inv_rect)
+    pygame.draw.rect(screen, BORDER_COLOR, inv_rect, width=BORDER_WIDTH)
+
+    item_size = int(HEIGHT / 6)
+    padding = int(item_size * 0.5)
+    font_h = DIALOG_FONT.get_height()
+    cols = max(1, (WIDTH - padding) // (item_size + padding))
+    for i, item in enumerate(items):
+        word = item["word"]
+        path = item["texture_path"]
+        sprite = pygame.image.load(path).convert_alpha()
+        sprite = pygame.transform.scale(sprite, (item_size, item_size))
+        col = i % cols
+        row = i // cols
+        x = padding + col * (item_size + padding)
+        y = padding + row * (item_size + font_h + padding)
+        screen.blit(sprite, (x, y))
+        text_surface = DIALOG_FONT.render(word, True, TEXT_COLOR)
+        text_rect = text_surface.get_rect(center=(x + item_size // 2, y + item_size + font_h // 2))
+        screen.blit(text_surface, text_rect)
+
 screen = pygame.display.set_mode((WIDTH, HEIGHT), pygame.DOUBLEBUF)
 pygame.display.set_caption("Checheck game")
 clock = pygame.time.Clock()
@@ -55,6 +80,8 @@ while running:
                 res = current_scene.interact()
                 if res:
                     current_scene = res
+            if event.key == pygame.K_q:
+                current_scene.toggle_inventory()
                 
     screen.fill((0, 0, 0))
     scene_info = current_scene.get_draw_data()
@@ -75,7 +102,9 @@ while running:
         rect = sprite.get_rect(topleft=(x_l, y_t))
         screen.blit(sprite, rect)
 
-    if scene_info["ui"]["mode"] == "dialog":
+    if scene_info["inventory"]["open"]:
+        draw_inventory(scene_info["inventory"]["items"])
+    elif scene_info["ui"]["mode"] == "dialog":
         dialog_rect = pygame.Rect(0, HEIGHT - DIALOG_HEIGHT, WIDTH, DIALOG_HEIGHT)
         pygame.draw.rect(screen, DIALOG_COLOR, dialog_rect, border_radius=20)
         pygame.draw.rect(screen, BORDER_COLOR, dialog_rect, border_radius=20, width=BORDER_WIDTH)

--- a/scene.py
+++ b/scene.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Callable, List, Optional, Tuple, Literal
+from data_helper import add_inventory_item, load_inventory
 import math
 
 Vec2 = Tuple[float, float]
@@ -170,6 +171,10 @@ class Scene:
     # Порядок отрисовки игрока:
     player_z: int = 0
 
+    # --- Инвентарь ---
+    # Открыт ли сейчас инвентарь
+    inventory_open: bool = False
+
     _active_dialog_npc_id: Optional[str] = None
 
     # ---------- Служебные ----------
@@ -202,7 +207,7 @@ class Scene:
         return best_obj, best_dist
 
     def _update_hint(self) -> None:
-        if self._is_dialog_active():
+        if self._is_dialog_active() or self.inventory_open:
             return
         obj, dist = self._nearest_interactable()
         if obj and dist <= self.interact_distance:
@@ -214,7 +219,7 @@ class Scene:
     # ---------- Перемещение (заблокировано при диалоге) ----------
 
     def _move(self, dx: float, dy: float) -> None:
-        if self._is_dialog_active():
+        if self._is_dialog_active() or self.inventory_open:
             return
 
         new_rect_x = self._player_rect().moved(dx, 0)
@@ -228,7 +233,7 @@ class Scene:
         self._update_hint()
 
     def move_forward(self, step: float = 2.0) -> None:
-        if self._is_dialog_active():
+        if self._is_dialog_active() or self.inventory_open:
             return
         self._move(0, -step)
         self.l += (self.c % self.player_speed) == 0
@@ -237,7 +242,7 @@ class Scene:
         self.player_texture_path = self.texture_path_to_player + f'/up{self.l % 5}.png'
 
     def move_back(self, step: float = 2.0) -> None:
-        if self._is_dialog_active():
+        if self._is_dialog_active() or self.inventory_open:
             return
         self._move(0, step)
         self.l += (self.c % self.player_speed) == 0
@@ -246,7 +251,7 @@ class Scene:
         self.player_texture_path = self.texture_path_to_player + f'/down{self.l}.png'
 
     def move_left(self, step: float = 2.0) -> None:
-        if self._is_dialog_active():
+        if self._is_dialog_active() or self.inventory_open:
             return
         self._move(-step, 0)
         self.l += (self.c % self.player_speed) == 0
@@ -255,7 +260,7 @@ class Scene:
         self.player_texture_path = self.texture_path_to_player + f'/left{self.l}.png'
 
     def move_right(self,step: float = 2.0) -> None:
-        if self._is_dialog_active():
+        if self._is_dialog_active() or self.inventory_open:
             return
         self._move(step, 0)
         self.l += (self.c % self.player_speed) == 0
@@ -298,6 +303,8 @@ class Scene:
     # ---------- Взаимодействие (E) ----------
 
     def unteract(self) -> Optional["Scene"]:
+        if self.inventory_open:
+            return None
         if self._active_dialog_npc_id is not None:
             return self.next_dialog_step()
         obj, dist = self._nearest_interactable()
@@ -310,6 +317,25 @@ class Scene:
 
     def interact(self) -> Optional["Scene"]:
         return self.unteract()
+
+    # ---------- Инвентарь ----------
+
+    def add_element(self, element: Tuple[str, str]) -> None:
+        """Добавить элемент (слово, путь к картинке) в инвентарь."""
+        word, path = element
+        add_inventory_item(word, path)
+
+    def toggle_inventory(self) -> None:
+        """Открыть/закрыть инвентарь. Нельзя открыть во время диалога."""
+        if self._is_dialog_active():
+            return
+        self.inventory_open = not self.inventory_open
+        if self.inventory_open:
+            # Скрываем подсказки при открытии инвентаря
+            self.text_window.hide()
+        else:
+            # После закрытия обновляем подсказку
+            self._update_hint()
 
     # ---------- Данные для рендера (включая пути к текстурам) ----------
 
@@ -348,6 +374,10 @@ class Scene:
                 "text": self.text_window.text,
                 "source_object_id": self.text_window.source_object_id,
                 "dialog_active_with": self._active_dialog_npc_id,
+            },
+            "inventory": {
+                "open": self.inventory_open,
+                "items": load_inventory(),
             },
         }
 


### PR DESCRIPTION
## Summary
- add inventory tracking and toggling to Scene class
- render inventory overlay and handle Q key to open/close
- persist inventory items in `data.json` instead of keeping them in `Scene`

## Testing
- `python -m py_compile scene.py render.py data_helper.py`


------
https://chatgpt.com/codex/tasks/task_e_68c53055d9a4832f9700646fe37edf00