### PR TITLE
Add multi-scene quest with vocabulary rewards

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,4 +1,4 @@
 {
     "inventory": [],
-    "scene": "root_scene"
+    "scene": "scene1"
 }

--- a/render.py
+++ b/render.py
@@ -116,33 +116,9 @@ while running:
             if event.key == pygame.K_q:
                 current_scene.toggle_inventory()
 
-    screen.fill((0, 0, 0))
-    scene_info = current_scene.get_draw_data()
-
-    sorted_objects = scene_info["objects"]
-    sorted_objects.append(scene_info["player"])
-    sorted_objects.sort(key=cmp_to_key(cmp_objects))
-
-    for obj in sorted_objects:
-        rect = obj["rect"]
-        x_l = rect.x1 * SCALE
-        y_t = rect.y1 * SCALE
-        width = (rect.x2 - rect.x1) * SCALE
-        height = (rect.y2 - rect.y1) * SCALE
-
-        sprite = pygame.image.load(obj["texture_path"]).convert_alpha()
-        sprite = pygame.transform.scale(sprite, (width, height))
-        rect = sprite.get_rect(topleft=(x_l, y_t))
-        screen.blit(sprite, rect)
-
-    if scene_info["inventory"]["open"]:
-        draw_inventory(scene_info["inventory"]["items"])
-    elif scene_info["ui"]["mode"] == "dialog":
-        draw_dialog(scene_info["ui"]["text"], scene_info["inventory"]["items"])
-    else:
-        if scene_info["ui"]["mode"] == "hint":
-            screen.blit(E_SPRITE, E_RECT)
-        keys = pygame.key.get_pressed()
+    # обновляем позицию игрока до отрисовки
+    keys = pygame.key.get_pressed()
+    if not current_scene.inventory_open and current_scene.text_window.mode != "dialog":
         if keys[pygame.K_w] or keys[pygame.K_UP]:
             current_scene.move_forward()
         if keys[pygame.K_s] or keys[pygame.K_DOWN]:
@@ -151,6 +127,31 @@ while running:
             current_scene.move_left()
         if keys[pygame.K_d] or keys[pygame.K_RIGHT]:
             current_scene.move_right()
+
+    scene_info = current_scene.get_draw_data()
+    screen.fill((0, 0, 0))
+
+    sorted_objects = scene_info["objects"] + [scene_info["player"]]
+    sorted_objects.sort(key=cmp_to_key(cmp_objects))
+
+    for obj in sorted_objects:
+        rect = obj["rect"]
+        x_l = int(rect.x1 * SCALE)
+        y_t = int(rect.y1 * SCALE)
+        width = int((rect.x2 - rect.x1) * SCALE)
+        height = int((rect.y2 - rect.y1) * SCALE)
+
+        sprite = pygame.image.load(obj["texture_path"]).convert_alpha()
+        sprite = pygame.transform.scale(sprite, (width, height))
+        screen.blit(sprite, (x_l, y_t))
+
+    if scene_info["inventory"]["open"]:
+        draw_inventory(scene_info["inventory"]["items"])
+    elif scene_info["ui"]["mode"] == "dialog":
+        draw_dialog(scene_info["ui"]["text"], scene_info["inventory"]["items"])
+    else:
+        if scene_info["ui"]["mode"] == "hint":
+            screen.blit(E_SPRITE, E_RECT)
 
     pygame.display.flip()
     clock.tick(FPS)

--- a/scene.py
+++ b/scene.py
@@ -308,8 +308,6 @@ class Scene:
         self._active_dialog_npc_id = None
         self.text_window.hide()
         next_scene = npc.on_interact(self)
-        if next_scene:
-            next_scene.player_pos = self.return_pos or self.player_pos
         return next_scene
 
     # ---------- Взаимодействие (E) ----------
@@ -332,9 +330,15 @@ class Scene:
         next_scene = self.unteract()
         if next_scene:
             if was_dialog:
-                next_scene.player_pos = self.return_pos or self.player_pos
+                next_scene.player_pos = self.player_pos
+                next_scene.return_pos = self.return_pos
             else:
-                next_scene.return_pos = self.player_pos
+                if "house" not in next_scene.id:
+                    next_scene.player_pos = self.player_pos
+                if self.return_pos is not None:
+                    next_scene.return_pos = self.return_pos
+                else:
+                    next_scene.return_pos = self.player_pos
         return next_scene
 
     # ---------- Инвентарь ----------

--- a/scenes.py
+++ b/scenes.py
@@ -14,7 +14,60 @@ Interacting with a highlighted object adds the corresponding word and
 placeholder image to the player's inventory.
 """
 
-from scene import Scene, StaticObject, NPC, Rect
+from scene import Scene, StaticObject, NPC, Rect, SceneFactory
+from typing import Optional
+
+
+def make_house_scene(
+    id: str,
+    outside_factory: SceneFactory,
+    highlight: bool = False,
+    next_scene_factory: Optional[SceneFactory] = None,
+) -> Scene:
+    """Generic interior of the left house with grandma."""
+    background = StaticObject(
+        id="bg",
+        rect=Rect(0, 0, 496, 279),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/backgrounds/home.png",
+        z=0,
+        scale_texture_to_rect=True,
+    )
+    door = StaticObject(
+        id="door_exit",
+        rect=Rect(220, 200, 276, 260),
+        solid=False,
+        interactable=True,
+        next_scene_factory=outside_factory,
+        texture_path=None,
+        z=1,
+    )
+    grandma_texture = (
+        "sprites/objects/grandma_highlited.png"
+        if highlight
+        else "sprites/objects/grandma.png"
+    )
+    ebi = StaticObject(
+        id="ebi",
+        name="Әби",
+        rect=Rect(160, 212, 192, 260),
+        solid=False,
+        interactable=highlight,
+        next_scene_factory=next_scene_factory,
+        texture_path=grandma_texture,
+        z=1,
+    )
+    return Scene(
+        id=id,
+        objects=[background, door, ebi],
+        player_pos=(230, 220),
+        player_size=(16, 16),
+        interact_distance=28.0,
+        player_texture_path="sprites/bahtiyar/down0.png",
+        scale_player_texture_to_rect=True,
+        player_z=2,
+    )
 
 
 def scene1() -> Scene:
@@ -47,20 +100,20 @@ def scene1() -> Scene:
     babay = StaticObject(
         id="babay",
         name="Бабай",
-        rect=Rect(360, 150, 420, 260),
+        rect=Rect(360, 212, 392, 260),
         solid=False,
         interactable=True,
         next_scene_factory=scene2,
         texture_path="sprites/objects/grandpa_highlited.png",
         z=2,
     )
-    ebi = StaticObject(
-        id="ebi",
-        name="Әби",
-        rect=Rect(80, 150, 140, 260),
+    door = StaticObject(
+        id="door",
+        rect=Rect(80, 180, 100, 220),
         solid=False,
-        interactable=False,
-        texture_path="sprites/objects/grandma.png",
+        interactable=True,
+        next_scene_factory=lambda: scene1_house(),
+        texture_path=None,
         z=2,
     )
     flower = StaticObject(
@@ -74,7 +127,7 @@ def scene1() -> Scene:
     )
     return Scene(
         id="scene1",
-        objects=[background, house1, house2, babay, ebi, flower],
+        objects=[background, house1, house2, door, babay, flower],
         player_pos=(230, 220),
         player_size=(16, 16),
         interact_distance=28.0,
@@ -111,17 +164,9 @@ def scene2() -> Scene:
         texture_path="sprites/objects/house2.png",
         z=1,
     )
-    ebi = StaticObject(
-        id="ebi",
-        rect=Rect(80, 150, 140, 260),
-        solid=False,
-        interactable=False,
-        texture_path="sprites/objects/grandma.png",
-        z=1,
-    )
     flower = StaticObject(
         id="flower",
-        rect=Rect(236, 210, 260, 238),
+        rect=Rect(236, 232, 260, 260),
         solid=False,
         interactable=False,
         texture_path="sprites/objects/flower.png",
@@ -130,7 +175,7 @@ def scene2() -> Scene:
     babay_big = NPC(
         id="babay_big",
         name="Бабай",
-        rect=Rect(20, 20, 220, 259),
+        rect=Rect(40, 212, 72, 260),
         solid=False,
         interactable=True,
         dialog_lines=["Сәлам!"],
@@ -143,7 +188,7 @@ def scene2() -> Scene:
     )
     scene = Scene(
         id="scene2",
-        objects=[background, house1, house2, ebi, flower, babay_big],
+        objects=[background, house1, house2, flower, babay_big],
         player_pos=(-100, -100),
         player_size=(16, 16),
         player_texture_path="sprites/bahtiyar/down0.png",
@@ -154,7 +199,7 @@ def scene2() -> Scene:
 
 
 def scene3() -> Scene:
-    """Walking scene with highlighted grandmother."""
+    """Walking scene leading to grandmother's house."""
     background = StaticObject(
         id="bg",
         rect=Rect(0, 0, 496, 279),
@@ -182,20 +227,19 @@ def scene3() -> Scene:
     )
     babay = StaticObject(
         id="babay",
-        rect=Rect(360, 150, 420, 260),
+        rect=Rect(360, 212, 392, 260),
         solid=False,
         interactable=False,
         texture_path="sprites/objects/grandpa.png",
         z=2,
     )
-    ebi = StaticObject(
-        id="ebi",
-        name="Әби",
-        rect=Rect(80, 150, 140, 260),
+    door = StaticObject(
+        id="door",
+        rect=Rect(80, 180, 100, 220),
         solid=False,
         interactable=True,
-        next_scene_factory=scene4,
-        texture_path="sprites/objects/grandma_highlited.png",
+        next_scene_factory=lambda: scene3_house(),
+        texture_path=None,
         z=2,
     )
     flower = StaticObject(
@@ -208,7 +252,7 @@ def scene3() -> Scene:
     )
     return Scene(
         id="scene3",
-        objects=[background, house1, house2, babay, ebi, flower],
+        objects=[background, house1, house2, door, babay, flower],
         player_pos=(230, 220),
         player_size=(16, 16),
         interact_distance=28.0,
@@ -225,46 +269,14 @@ def scene4() -> Scene:
         rect=Rect(0, 0, 496, 279),
         solid=False,
         interactable=False,
-        texture_path="sprites/backgrounds/root.png",
+        texture_path="sprites/backgrounds/home.png",
         z=0,
         scale_texture_to_rect=True,
-    )
-    house1 = StaticObject(
-        id="house1",
-        rect=Rect(40, 120, 120, 200),
-        solid=False,
-        interactable=False,
-        texture_path="sprites/objects/house1.png",
-        z=1,
-    )
-    house2 = StaticObject(
-        id="house2",
-        rect=Rect(336, 120, 416, 200),
-        solid=False,
-        interactable=False,
-        texture_path="sprites/objects/house2.png",
-        z=1,
-    )
-    babay = StaticObject(
-        id="babay",
-        rect=Rect(360, 150, 420, 260),
-        solid=False,
-        interactable=False,
-        texture_path="sprites/objects/grandpa.png",
-        z=1,
-    )
-    flower = StaticObject(
-        id="flower",
-        rect=Rect(236, 210, 260, 238),
-        solid=False,
-        interactable=False,
-        texture_path="sprites/objects/flower.png",
-        z=1,
     )
     ebi_big = NPC(
         id="ebi_big",
         name="Әби",
-        rect=Rect(20, 20, 220, 259),
+        rect=Rect(40, 212, 72, 260),
         solid=False,
         interactable=True,
         dialog_lines=["Исәнмесез, бир миңа чәчәк"],
@@ -277,7 +289,7 @@ def scene4() -> Scene:
     )
     scene = Scene(
         id="scene4",
-        objects=[background, house1, house2, babay, flower, ebi_big],
+        objects=[background, ebi_big],
         player_pos=(-100, -100),
         player_size=(16, 16),
         player_texture_path="sprites/bahtiyar/down0.png",
@@ -316,24 +328,25 @@ def scene5() -> Scene:
     )
     babay = StaticObject(
         id="babay",
-        rect=Rect(360, 150, 420, 260),
+        rect=Rect(360, 212, 392, 260),
         solid=False,
         interactable=False,
         texture_path="sprites/objects/grandpa.png",
         z=2,
     )
-    ebi = StaticObject(
-        id="ebi",
-        rect=Rect(80, 150, 140, 260),
+    door = StaticObject(
+        id="door",
+        rect=Rect(80, 180, 100, 220),
         solid=False,
-        interactable=False,
-        texture_path="sprites/objects/grandma.png",
+        interactable=True,
+        next_scene_factory=lambda: scene5_house(),
+        texture_path=None,
         z=2,
     )
     flower = StaticObject(
         id="flower",
         name="Чәчәк",
-        rect=Rect(236, 210, 260, 238),
+        rect=Rect(236, 232, 260, 260),
         solid=False,
         interactable=True,
         next_scene_factory=scene6,
@@ -342,7 +355,7 @@ def scene5() -> Scene:
     )
     return Scene(
         id="scene5",
-        objects=[background, house1, house2, babay, ebi, flower],
+        objects=[background, house1, house2, door, babay, flower],
         player_pos=(230, 220),
         player_size=(16, 16),
         interact_distance=28.0,
@@ -381,24 +394,16 @@ def scene6() -> Scene:
     )
     babay = StaticObject(
         id="babay",
-        rect=Rect(360, 150, 420, 260),
+        rect=Rect(360, 212, 392, 260),
         solid=False,
         interactable=False,
         texture_path="sprites/objects/grandpa.png",
         z=1,
     )
-    ebi = StaticObject(
-        id="ebi",
-        rect=Rect(80, 150, 140, 260),
-        solid=False,
-        interactable=False,
-        texture_path="sprites/objects/grandma.png",
-        z=1,
-    )
     flower_big = NPC(
         id="flower_big",
         name="Чәчәк",
-        rect=Rect(150, 30, 346, 250),
+        rect=Rect(220, 212, 252, 260),
         solid=False,
         interactable=True,
         dialog_lines=["Чәчәк"],
@@ -411,7 +416,7 @@ def scene6() -> Scene:
     )
     scene = Scene(
         id="scene6",
-        objects=[background, house1, house2, babay, ebi, flower_big],
+        objects=[background, house1, house2, babay, flower_big],
         player_pos=(-100, -100),
         player_size=(16, 16),
         player_texture_path="sprites/bahtiyar/down0.png",
@@ -450,25 +455,24 @@ def scene7() -> Scene:
     )
     babay = StaticObject(
         id="babay",
-        rect=Rect(360, 150, 420, 260),
+        rect=Rect(360, 212, 392, 260),
         solid=False,
         interactable=False,
         texture_path="sprites/objects/grandpa.png",
         z=2,
     )
-    ebi = StaticObject(
-        id="ebi",
-        name="Әби",
-        rect=Rect(80, 150, 140, 260),
+    door = StaticObject(
+        id="door",
+        rect=Rect(80, 180, 100, 220),
         solid=False,
         interactable=True,
-        next_scene_factory=scene8,
-        texture_path="sprites/objects/grandma_highlited.png",
+        next_scene_factory=lambda: scene7_house(),
+        texture_path=None,
         z=2,
     )
     flower = StaticObject(
         id="flower",
-        rect=Rect(236, 210, 260, 238),
+        rect=Rect(236, 232, 260, 260),
         solid=False,
         interactable=False,
         texture_path="sprites/objects/flower.png",
@@ -476,7 +480,7 @@ def scene7() -> Scene:
     )
     return Scene(
         id="scene7",
-        objects=[background, house1, house2, babay, ebi, flower],
+        objects=[background, house1, house2, door, babay, flower],
         player_pos=(230, 220),
         player_size=(16, 16),
         interact_distance=28.0,
@@ -493,46 +497,14 @@ def scene8() -> Scene:
         rect=Rect(0, 0, 496, 279),
         solid=False,
         interactable=False,
-        texture_path="sprites/backgrounds/root.png",
+        texture_path="sprites/backgrounds/home.png",
         z=0,
         scale_texture_to_rect=True,
-    )
-    house1 = StaticObject(
-        id="house1",
-        rect=Rect(40, 120, 120, 200),
-        solid=False,
-        interactable=False,
-        texture_path="sprites/objects/house1.png",
-        z=1,
-    )
-    house2 = StaticObject(
-        id="house2",
-        rect=Rect(336, 120, 416, 200),
-        solid=False,
-        interactable=False,
-        texture_path="sprites/objects/house2.png",
-        z=1,
-    )
-    babay = StaticObject(
-        id="babay",
-        rect=Rect(360, 150, 420, 260),
-        solid=False,
-        interactable=False,
-        texture_path="sprites/objects/grandpa.png",
-        z=1,
-    )
-    flower = StaticObject(
-        id="flower",
-        rect=Rect(236, 210, 260, 238),
-        solid=False,
-        interactable=False,
-        texture_path="sprites/objects/flower.png",
-        z=1,
     )
     ebi_big = NPC(
         id="ebi_big_final",
         name="Әби",
-        rect=Rect(20, 20, 220, 259),
+        rect=Rect(40, 212, 72, 260),
         solid=False,
         interactable=True,
         dialog_lines=["Рәхмәт"],
@@ -544,7 +516,7 @@ def scene8() -> Scene:
     )
     scene = Scene(
         id="scene8",
-        objects=[background, house1, house2, babay, flower, ebi_big],
+        objects=[background, ebi_big],
         player_pos=(-100, -100),
         player_size=(16, 16),
         player_texture_path="sprites/bahtiyar/down0.png",
@@ -583,23 +555,24 @@ def scene9() -> Scene:
     )
     babay = StaticObject(
         id="babay",
-        rect=Rect(360, 150, 420, 260),
+        rect=Rect(360, 212, 392, 260),
         solid=False,
         interactable=False,
         texture_path="sprites/objects/grandpa.png",
         z=2,
     )
-    ebi = StaticObject(
-        id="ebi",
-        rect=Rect(80, 150, 140, 260),
+    door = StaticObject(
+        id="door",
+        rect=Rect(80, 180, 100, 220),
         solid=False,
-        interactable=False,
-        texture_path="sprites/objects/grandma.png",
+        interactable=True,
+        next_scene_factory=lambda: scene9_house(),
+        texture_path=None,
         z=2,
     )
     flower = StaticObject(
         id="flower",
-        rect=Rect(236, 210, 260, 238),
+        rect=Rect(236, 232, 260, 260),
         solid=False,
         interactable=False,
         texture_path="sprites/objects/flower.png",
@@ -607,7 +580,7 @@ def scene9() -> Scene:
     )
     return Scene(
         id="scene9",
-        objects=[background, house1, house2, babay, ebi, flower],
+        objects=[background, house1, house2, door, babay, flower],
         player_pos=(230, 220),
         player_size=(16, 16),
         interact_distance=28.0,
@@ -615,6 +588,26 @@ def scene9() -> Scene:
         scale_player_texture_to_rect=True,
         player_z=3,
     )
+
+
+def scene1_house() -> Scene:
+    return make_house_scene("scene1_house", scene1)
+
+
+def scene3_house() -> Scene:
+    return make_house_scene("scene3_house", scene3, True, scene4)
+
+
+def scene5_house() -> Scene:
+    return make_house_scene("scene5_house", scene5)
+
+
+def scene7_house() -> Scene:
+    return make_house_scene("scene7_house", scene7, True, scene8)
+
+
+def scene9_house() -> Scene:
+    return make_house_scene("scene9_house", scene9)
 
 
 scenes = {
@@ -627,5 +620,10 @@ scenes = {
     "scene7": scene7(),
     "scene8": scene8(),
     "scene9": scene9(),
+    "scene1_house": scene1_house(),
+    "scene3_house": scene3_house(),
+    "scene5_house": scene5_house(),
+    "scene7_house": scene7_house(),
+    "scene9_house": scene9_house(),
 }
 

--- a/scenes.py
+++ b/scenes.py
@@ -36,7 +36,7 @@ def make_house_scene(
     )
     door = StaticObject(
         id="door_exit",
-        rect=Rect(220, 200, 276, 260),
+        rect=Rect(80, 200, 120, 260),
         solid=False,
         interactable=True,
         next_scene_factory=outside_factory,
@@ -285,7 +285,7 @@ def scene4() -> Scene:
         texture_path="sprites/objects/grandma.png",
         z=2,
         reward=("әби", "sprites/objects/grandma.png"),
-        next_scene_factory=scene5,
+        next_scene_factory=scene5_house,
     )
     scene = Scene(
         id="scene4",
@@ -512,7 +512,7 @@ def scene8() -> Scene:
         persist_progress=True,
         texture_path="sprites/objects/grandma.png",
         z=2,
-        next_scene_factory=scene9,
+        next_scene_factory=scene9_house,
     )
     scene = Scene(
         id="scene8",

--- a/scenes.py
+++ b/scenes.py
@@ -1,66 +1,26 @@
-from scene import *
+"""Game scenes implementing the full quest storyline.
 
-home_b = root_b = False
+Scene order:
+1. Walk to the highlighted grandfather.
+2. Talk with grandfather.
+3. Walk to the highlighted grandmother.
+4. Talk with grandmother (asks for a flower).
+5. Walk to the highlighted flower.
+6. Talk with flower (learn the word).
+7. Return to highlighted grandmother.
+8. Final dialog with grandmother.
 
+Interacting with a highlighted object adds the corresponding word and
+placeholder image to the player's inventory.
+"""
 
-def home_scene() -> Scene:
-    global home_b
-    if home_b:
-        return scenes["home_scene"]
-    field = StaticObject(
-        id='field',
-        name='Поле',
-        rect=Rect(0, 0, 496, 279),
-        solid=False,
-        interactable=False,
-        texture_path="sprites/backgrounds/home.png",
-        z=0,
-        scale_texture_to_rect=True,
-    )
-    granny = NPC(
-        id="npc_granny",
-        name="Әби",
-        rect=Rect(110, 130, 200, 250),
-        solid=False,
-        interactable=True,
-        dialog_lines=[
-            "Сәлам!",
-            "Как настроение?",
-            "Учить — свет, не учить — тьма.",
-            "Ладно, увидимся позже!"
-        ],
-        repeatable=False,
-        persist_progress=True,
-        texture_path="sprites/objects/grandma.png",
-        z=1,
-    )
-    door = StaticObject(
-        id="home_scene",
-        rect=Rect(33, 21, 151, 166),
-        solid=False,
-        interactable=True,
-        next_scene_factory=root_scene,
-        texture_path="sprites/objects/house1.png",
-        z=-1,
-    )
-    home_b = True
-    return Scene(
-        id="home_scene",
-        objects=[field, granny, door],
-        player_pos=(20, 20),
-        player_size=(120, 120),
-        player_texture_path=f"sprites/bahtiyar/down{0}.png",
-        player_z=1
-    )
+from scene import Scene, StaticObject, NPC, Rect
 
 
-def root_scene() -> Scene:
-    global root_b
-    if root_b:
-        return scenes["root_scene"]
-    field = StaticObject(
-        id='field',
-        name='Поле',
+def scene1() -> Scene:
+    """Walking scene with highlighted grandfather."""
+    background = StaticObject(
+        id="bg",
         rect=Rect(0, 0, 496, 279),
         solid=False,
         interactable=False,
@@ -68,48 +28,539 @@ def root_scene() -> Scene:
         z=0,
         scale_texture_to_rect=True,
     )
-    door = StaticObject(
-        id="home_root",
-        rect=Rect(200, 100, 250, 150),
+    house1 = StaticObject(
+        id="house1",
+        rect=Rect(40, 120, 120, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house1.png",
+        z=1,
+    )
+    house2 = StaticObject(
+        id="house2",
+        rect=Rect(336, 120, 416, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house2.png",
+        z=1,
+    )
+    babay = StaticObject(
+        id="babay",
+        name="Бабай",
+        rect=Rect(360, 150, 420, 260),
         solid=False,
         interactable=True,
-        next_scene_factory=home_scene,
-        texture_path="sprites/objects/house1.png",
-        z=1,
+        next_scene_factory=scene2,
+        texture_path="sprites/objects/grandpa_highlited.png",
+        z=2,
     )
-
-    block_line = StaticObject(
-        id="block_line",
-        rect=Rect(205, 125, 245, 140),
-        solid=True,
+    ebi = StaticObject(
+        id="ebi",
+        name="Әби",
+        rect=Rect(80, 150, 140, 260),
+        solid=False,
         interactable=False,
-        texture_path="sprites/bahtiyar/down0.png",
-        z=-1,
+        texture_path="sprites/objects/grandma.png",
+        z=2,
     )
-
-    wall = StaticObject(
-        id="wall_1",
-        rect=Rect(0, 0, 200, 16),
-        solid=True,
+    flower = StaticObject(
+        id="flower",
+        name="Чәчәк",
+        rect=Rect(236, 210, 260, 238),
+        solid=False,
         interactable=False,
-        texture_path="sprites/objects/house1.png",
-        z=1,
-        scale_texture_to_rect=True,
+        texture_path="sprites/objects/flower.png",
+        z=2,
     )
-    root_b = True
     return Scene(
-        id="root_scene",
-        objects=[field, door, wall, block_line],
-        player_pos=(30, 90),
+        id="scene1",
+        objects=[background, house1, house2, babay, ebi, flower],
+        player_pos=(230, 220),
         player_size=(16, 16),
         interact_distance=28.0,
-        player_texture_path=f"sprites/bahtiyar/down{0}.png",
+        player_texture_path="sprites/bahtiyar/down0.png",
         scale_player_texture_to_rect=True,
-        player_z=1,
+        player_z=3,
     )
+
+
+def scene2() -> Scene:
+    """Dialog with grandfather teaching the word 'бабай'."""
+    background = StaticObject(
+        id="bg",
+        rect=Rect(0, 0, 496, 279),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/backgrounds/root.png",
+        z=0,
+        scale_texture_to_rect=True,
+    )
+    house1 = StaticObject(
+        id="house1",
+        rect=Rect(40, 120, 120, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house1.png",
+        z=1,
+    )
+    house2 = StaticObject(
+        id="house2",
+        rect=Rect(336, 120, 416, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house2.png",
+        z=1,
+    )
+    ebi = StaticObject(
+        id="ebi",
+        rect=Rect(80, 150, 140, 260),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/grandma.png",
+        z=1,
+    )
+    flower = StaticObject(
+        id="flower",
+        rect=Rect(236, 210, 260, 238),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/flower.png",
+        z=1,
+    )
+    babay_big = NPC(
+        id="babay_big",
+        name="Бабай",
+        rect=Rect(20, 20, 220, 259),
+        solid=False,
+        interactable=True,
+        dialog_lines=["Сәлам!"],
+        repeatable=False,
+        persist_progress=True,
+        texture_path="sprites/objects/grandpa.png",
+        z=2,
+        reward=("бабай", "sprites/objects/grandpa.png"),
+        next_scene_factory=scene3,
+    )
+    scene = Scene(
+        id="scene2",
+        objects=[background, house1, house2, ebi, flower, babay_big],
+        player_pos=(-100, -100),
+        player_size=(16, 16),
+        player_texture_path="sprites/bahtiyar/down0.png",
+        player_z=-1,
+    )
+    scene.start_dialog_with(babay_big)
+    return scene
+
+
+def scene3() -> Scene:
+    """Walking scene with highlighted grandmother."""
+    background = StaticObject(
+        id="bg",
+        rect=Rect(0, 0, 496, 279),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/backgrounds/root.png",
+        z=0,
+        scale_texture_to_rect=True,
+    )
+    house1 = StaticObject(
+        id="house1",
+        rect=Rect(40, 120, 120, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house1.png",
+        z=1,
+    )
+    house2 = StaticObject(
+        id="house2",
+        rect=Rect(336, 120, 416, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house2.png",
+        z=1,
+    )
+    babay = StaticObject(
+        id="babay",
+        rect=Rect(360, 150, 420, 260),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/grandpa.png",
+        z=2,
+    )
+    ebi = StaticObject(
+        id="ebi",
+        name="Әби",
+        rect=Rect(80, 150, 140, 260),
+        solid=False,
+        interactable=True,
+        next_scene_factory=scene4,
+        texture_path="sprites/objects/grandma_highlited.png",
+        z=2,
+    )
+    flower = StaticObject(
+        id="flower",
+        rect=Rect(236, 210, 260, 238),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/flower.png",
+        z=2,
+    )
+    return Scene(
+        id="scene3",
+        objects=[background, house1, house2, babay, ebi, flower],
+        player_pos=(230, 220),
+        player_size=(16, 16),
+        interact_distance=28.0,
+        player_texture_path="sprites/bahtiyar/down0.png",
+        scale_player_texture_to_rect=True,
+        player_z=3,
+    )
+
+
+def scene4() -> Scene:
+    """Dialog with grandmother asking for a flower."""
+    background = StaticObject(
+        id="bg",
+        rect=Rect(0, 0, 496, 279),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/backgrounds/root.png",
+        z=0,
+        scale_texture_to_rect=True,
+    )
+    house1 = StaticObject(
+        id="house1",
+        rect=Rect(40, 120, 120, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house1.png",
+        z=1,
+    )
+    house2 = StaticObject(
+        id="house2",
+        rect=Rect(336, 120, 416, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house2.png",
+        z=1,
+    )
+    babay = StaticObject(
+        id="babay",
+        rect=Rect(360, 150, 420, 260),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/grandpa.png",
+        z=1,
+    )
+    flower = StaticObject(
+        id="flower",
+        rect=Rect(236, 210, 260, 238),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/flower.png",
+        z=1,
+    )
+    ebi_big = NPC(
+        id="ebi_big",
+        name="Әби",
+        rect=Rect(20, 20, 220, 259),
+        solid=False,
+        interactable=True,
+        dialog_lines=["Исәнмесез, бир миңа чәчәк"],
+        repeatable=False,
+        persist_progress=True,
+        texture_path="sprites/objects/grandma.png",
+        z=2,
+        reward=("әби", "sprites/objects/grandma.png"),
+        next_scene_factory=scene5,
+    )
+    scene = Scene(
+        id="scene4",
+        objects=[background, house1, house2, babay, flower, ebi_big],
+        player_pos=(-100, -100),
+        player_size=(16, 16),
+        player_texture_path="sprites/bahtiyar/down0.png",
+        player_z=-1,
+    )
+    scene.start_dialog_with(ebi_big)
+    return scene
+
+
+def scene5() -> Scene:
+    """Walking scene with highlighted flower."""
+    background = StaticObject(
+        id="bg",
+        rect=Rect(0, 0, 496, 279),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/backgrounds/root.png",
+        z=0,
+        scale_texture_to_rect=True,
+    )
+    house1 = StaticObject(
+        id="house1",
+        rect=Rect(40, 120, 120, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house1.png",
+        z=1,
+    )
+    house2 = StaticObject(
+        id="house2",
+        rect=Rect(336, 120, 416, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house2.png",
+        z=1,
+    )
+    babay = StaticObject(
+        id="babay",
+        rect=Rect(360, 150, 420, 260),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/grandpa.png",
+        z=2,
+    )
+    ebi = StaticObject(
+        id="ebi",
+        rect=Rect(80, 150, 140, 260),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/grandma.png",
+        z=2,
+    )
+    flower = StaticObject(
+        id="flower",
+        name="Чәчәк",
+        rect=Rect(236, 210, 260, 238),
+        solid=False,
+        interactable=True,
+        next_scene_factory=scene6,
+        texture_path="sprites/objects/flower_highlited.png",
+        z=2,
+    )
+    return Scene(
+        id="scene5",
+        objects=[background, house1, house2, babay, ebi, flower],
+        player_pos=(230, 220),
+        player_size=(16, 16),
+        interact_distance=28.0,
+        player_texture_path="sprites/bahtiyar/down0.png",
+        scale_player_texture_to_rect=True,
+        player_z=3,
+    )
+
+
+def scene6() -> Scene:
+    """Dialog with flower teaching the word 'чәчәк'."""
+    background = StaticObject(
+        id="bg",
+        rect=Rect(0, 0, 496, 279),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/backgrounds/root.png",
+        z=0,
+        scale_texture_to_rect=True,
+    )
+    house1 = StaticObject(
+        id="house1",
+        rect=Rect(40, 120, 120, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house1.png",
+        z=1,
+    )
+    house2 = StaticObject(
+        id="house2",
+        rect=Rect(336, 120, 416, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house2.png",
+        z=1,
+    )
+    babay = StaticObject(
+        id="babay",
+        rect=Rect(360, 150, 420, 260),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/grandpa.png",
+        z=1,
+    )
+    ebi = StaticObject(
+        id="ebi",
+        rect=Rect(80, 150, 140, 260),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/grandma.png",
+        z=1,
+    )
+    flower_big = NPC(
+        id="flower_big",
+        name="Чәчәк",
+        rect=Rect(150, 30, 346, 250),
+        solid=False,
+        interactable=True,
+        dialog_lines=["Чәчәк"],
+        repeatable=False,
+        persist_progress=True,
+        texture_path="sprites/objects/flower.png",
+        z=2,
+        reward=("чәчәк", "sprites/objects/flower.png"),
+        next_scene_factory=scene7,
+    )
+    scene = Scene(
+        id="scene6",
+        objects=[background, house1, house2, babay, ebi, flower_big],
+        player_pos=(-100, -100),
+        player_size=(16, 16),
+        player_texture_path="sprites/bahtiyar/down0.png",
+        player_z=-1,
+    )
+    scene.start_dialog_with(flower_big)
+    return scene
+
+
+def scene7() -> Scene:
+    """Walking scene returning to grandmother with the flower."""
+    background = StaticObject(
+        id="bg",
+        rect=Rect(0, 0, 496, 279),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/backgrounds/root.png",
+        z=0,
+        scale_texture_to_rect=True,
+    )
+    house1 = StaticObject(
+        id="house1",
+        rect=Rect(40, 120, 120, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house1.png",
+        z=1,
+    )
+    house2 = StaticObject(
+        id="house2",
+        rect=Rect(336, 120, 416, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house2.png",
+        z=1,
+    )
+    babay = StaticObject(
+        id="babay",
+        rect=Rect(360, 150, 420, 260),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/grandpa.png",
+        z=2,
+    )
+    ebi = StaticObject(
+        id="ebi",
+        name="Әби",
+        rect=Rect(80, 150, 140, 260),
+        solid=False,
+        interactable=True,
+        next_scene_factory=scene8,
+        texture_path="sprites/objects/grandma_highlited.png",
+        z=2,
+    )
+    flower = StaticObject(
+        id="flower",
+        rect=Rect(236, 210, 260, 238),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/flower.png",
+        z=2,
+    )
+    return Scene(
+        id="scene7",
+        objects=[background, house1, house2, babay, ebi, flower],
+        player_pos=(230, 220),
+        player_size=(16, 16),
+        interact_distance=28.0,
+        player_texture_path="sprites/bahtiyar/down0.png",
+        scale_player_texture_to_rect=True,
+        player_z=3,
+    )
+
+
+def scene8() -> Scene:
+    """Final dialog where grandmother thanks the player."""
+    background = StaticObject(
+        id="bg",
+        rect=Rect(0, 0, 496, 279),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/backgrounds/root.png",
+        z=0,
+        scale_texture_to_rect=True,
+    )
+    house1 = StaticObject(
+        id="house1",
+        rect=Rect(40, 120, 120, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house1.png",
+        z=1,
+    )
+    house2 = StaticObject(
+        id="house2",
+        rect=Rect(336, 120, 416, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house2.png",
+        z=1,
+    )
+    babay = StaticObject(
+        id="babay",
+        rect=Rect(360, 150, 420, 260),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/grandpa.png",
+        z=1,
+    )
+    flower = StaticObject(
+        id="flower",
+        rect=Rect(236, 210, 260, 238),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/flower.png",
+        z=1,
+    )
+    ebi_big = NPC(
+        id="ebi_big_final",
+        name="Әби",
+        rect=Rect(20, 20, 220, 259),
+        solid=False,
+        interactable=True,
+        dialog_lines=["Рәхмәт"],
+        repeatable=False,
+        persist_progress=True,
+        texture_path="sprites/objects/grandma.png",
+        z=2,
+    )
+    scene = Scene(
+        id="scene8",
+        objects=[background, house1, house2, babay, flower, ebi_big],
+        player_pos=(-100, -100),
+        player_size=(16, 16),
+        player_texture_path="sprites/bahtiyar/down0.png",
+        player_z=-1,
+    )
+    scene.start_dialog_with(ebi_big)
+    return scene
 
 
 scenes = {
-    "root_scene": root_scene(),
-    "home_scene": home_scene()
+    "scene1": scene1(),
+    "scene2": scene2(),
+    "scene3": scene3(),
+    "scene4": scene4(),
+    "scene5": scene5(),
+    "scene6": scene6(),
+    "scene7": scene7(),
+    "scene8": scene8(),
 }
+

--- a/scenes.py
+++ b/scenes.py
@@ -540,6 +540,7 @@ def scene8() -> Scene:
         persist_progress=True,
         texture_path="sprites/objects/grandma.png",
         z=2,
+        next_scene_factory=scene9,
     )
     scene = Scene(
         id="scene8",
@@ -553,6 +554,69 @@ def scene8() -> Scene:
     return scene
 
 
+def scene9() -> Scene:
+    """Final walking scene after grandmother thanks the player."""
+    background = StaticObject(
+        id="bg",
+        rect=Rect(0, 0, 496, 279),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/backgrounds/root.png",
+        z=0,
+        scale_texture_to_rect=True,
+    )
+    house1 = StaticObject(
+        id="house1",
+        rect=Rect(40, 120, 120, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house1.png",
+        z=1,
+    )
+    house2 = StaticObject(
+        id="house2",
+        rect=Rect(336, 120, 416, 200),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/house2.png",
+        z=1,
+    )
+    babay = StaticObject(
+        id="babay",
+        rect=Rect(360, 150, 420, 260),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/grandpa.png",
+        z=2,
+    )
+    ebi = StaticObject(
+        id="ebi",
+        rect=Rect(80, 150, 140, 260),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/grandma.png",
+        z=2,
+    )
+    flower = StaticObject(
+        id="flower",
+        rect=Rect(236, 210, 260, 238),
+        solid=False,
+        interactable=False,
+        texture_path="sprites/objects/flower.png",
+        z=2,
+    )
+    return Scene(
+        id="scene9",
+        objects=[background, house1, house2, babay, ebi, flower],
+        player_pos=(230, 220),
+        player_size=(16, 16),
+        interact_distance=28.0,
+        player_texture_path="sprites/bahtiyar/down0.png",
+        scale_player_texture_to_rect=True,
+        player_z=3,
+    )
+
+
 scenes = {
     "scene1": scene1(),
     "scene2": scene2(),
@@ -562,5 +626,6 @@ scenes = {
     "scene6": scene6(),
     "scene7": scene7(),
     "scene8": scene8(),
+    "scene9": scene9(),
 }
 


### PR DESCRIPTION
## Summary
- Build eight-scene storyline featuring grandpa, grandma and flower interactions
- Each highlighted object teaches a new Tatar word with placeholder imagery
- Start the game from the new quest and load scenes accordingly

## Testing
- `python -m py_compile scene.py scenes.py render.py data_helper.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5542fa400832fa210fae96febb8db